### PR TITLE
NO more guava optionals

### DIFF
--- a/src/main/java/com/openlattice/mail/EmailRequest.java
+++ b/src/main/java/com/openlattice/mail/EmailRequest.java
@@ -20,27 +20,26 @@
 
 package com.openlattice.mail;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Arrays;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class EmailRequest {
-    protected static final String    FROM_FIELD = "from";
-    protected static final String    TO_FIELD   = "to";
-    protected static final String    CC_FIELD   = "cc";
-    protected static final String    BCC_FIELD  = "bcc";
-    private final Optional<String>   from;
-    private final String[]           to;
-    private final Optional<String[]> cc;
-    private final Optional<String[]> bcc;
+    protected static final String             FROM_FIELD = "from";
+    protected static final String             TO_FIELD   = "to";
+    protected static final String             CC_FIELD   = "cc";
+    protected static final String             BCC_FIELD  = "bcc";
+    private final          Optional<String>   from;
+    private final          String[]           to;
+    private final          Optional<String[]> cc;
+    private final          Optional<String[]> bcc;
 
     public EmailRequest(
             Optional<String> from,
@@ -49,15 +48,8 @@ public class EmailRequest {
             Optional<String[]> bcc ) {
 
         this.from = Preconditions.checkNotNull( from );
-        this.to = ImmutableList.copyOf( Iterables.filter( Arrays.asList( Preconditions.checkNotNull( to ) ),
-                new Predicate<String>() {
-
-                    @Override
-                    public boolean apply( String input ) {
-                        return StringUtils.isNotBlank( input );
-                    }
-
-                } ) ).toArray( new String[ 0 ] );
+        this.to = ImmutableList.copyOf( Arrays.asList( Preconditions.checkNotNull( to ) ).stream()
+                .filter( input -> StringUtils.isNotBlank( input ) ).collect( Collectors.toList() ) ).toArray( new String[ 0 ] );
         this.cc = Preconditions.checkNotNull( cc );
         this.bcc = Preconditions.checkNotNull( bcc );
         Preconditions.checkState( this.to.length > 0 );

--- a/src/main/java/com/openlattice/mail/RenderableEmailRequest.java
+++ b/src/main/java/com/openlattice/mail/RenderableEmailRequest.java
@@ -20,26 +20,25 @@
 
 package com.openlattice.mail;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import jodd.mail.EmailAttachment;
 import org.apache.commons.lang3.StringUtils;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-
+import java.util.Optional;
 
 public class RenderableEmailRequest extends EmailRequest {
-    private static final String               TEMPLATE_PATH_FIELD    = "templatePath";
-    private static final String               SUBJECT_FIELD          = "subject";
-    private static final String               TEMPLATE_OBJS_FIELD    = "templateObjs";
-    private static final String               ATTACHMENTS_FIELD      = "attachments";
-    private static final String               ATTACHMENT_PATHS_FIELD = "attachmentPaths";
-    private final Optional<String>            subject;
-    private final String                      templatePath;
-    private final Optional<Object>            templateObjs;
-    private final Optional<EmailAttachment[]> byteArrayAttachment;
-    private final Optional<String[]>          attachmentPaths;
+    private static final String                      TEMPLATE_PATH_FIELD    = "templatePath";
+    private static final String                      SUBJECT_FIELD          = "subject";
+    private static final String                      TEMPLATE_OBJS_FIELD    = "templateObjs";
+    private static final String                      ATTACHMENTS_FIELD      = "attachments";
+    private static final String                      ATTACHMENT_PATHS_FIELD = "attachmentPaths";
+    private final        Optional<String>            subject;
+    private final        String                      templatePath;
+    private final        Optional<Object>            templateObjs;
+    private final        Optional<EmailAttachment[]> byteArrayAttachment;
+    private final        Optional<String[]>          attachmentPaths;
 
     @JsonCreator
     public RenderableEmailRequest(

--- a/src/main/java/com/openlattice/mail/gravatar/Gravatar.java
+++ b/src/main/java/com/openlattice/mail/gravatar/Gravatar.java
@@ -20,25 +20,23 @@
 
 package com.openlattice.mail.gravatar;
 
+import com.google.common.collect.ImmutableMap;
+import com.openlattice.mail.MailServiceClient;
+import com.openlattice.mail.RenderableEmailRequest;
 import com.openlattice.mail.requirements.ScribeRequirements;
 import com.openlattice.mail.templates.EmailTemplate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.inject.Inject;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.inject.Inject;
-
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import com.openlattice.mail.MailServiceClient;
-import com.openlattice.mail.RenderableEmailRequest;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 
 public class Gravatar {
     private final static int    DEFAULT_SIZE       = 80;
@@ -69,7 +67,7 @@ public class Gravatar {
     }
 
     private String formatUrlParameters() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         if ( size != DEFAULT_SIZE )
             params.add( "s=" + size );
         params.add( "d=" + DEFAULT_AVATAR_URL );
@@ -90,15 +88,15 @@ public class Gravatar {
         
         MailServiceClient mailService = new MailServiceClient( requirements.getEmailQueue() );
         RenderableEmailRequest emailRequest = new RenderableEmailRequest(
-                Optional.of( EmailTemplate.getCourierEmailAddress() ),
+                java.util.Optional.of( EmailTemplate.getCourierEmailAddress() ),
                 new String[] { "outage@openlattice.com" },
-                Optional.absent(),
-                Optional.absent(),
+                Optional.empty(),
+                Optional.empty(),
                 EmailTemplate.INTERNAL_ERROR.getPath(),
-                Optional.of( EmailTemplate.INTERNAL_ERROR.getSubject() ),
-                Optional.of( ImmutableMap.of( "message", sw.toString() ) ),
-                Optional.absent(),
-                Optional.absent());
+                java.util.Optional.of( EmailTemplate.INTERNAL_ERROR.getSubject() ),
+                java.util.Optional.of( ImmutableMap.of( "message", sw.toString() ) ),
+                Optional.empty(),
+                Optional.empty());
         mailService.spool( emailRequest );
         
     }

--- a/src/test/java/com/openlattice/mail/RenderableEmailRequestTest.java
+++ b/src/test/java/com/openlattice/mail/RenderableEmailRequestTest.java
@@ -20,12 +20,13 @@
 
 package com.openlattice.mail;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.openlattice.serializer.AbstractJacksonSerializationTest;
-import java.util.Map;
 import jodd.mail.EmailAttachment;
 import org.junit.Test;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class RenderableEmailRequestTest extends AbstractJacksonSerializationTest<RenderableEmailRequest> {
 
@@ -39,15 +40,15 @@ public class RenderableEmailRequestTest extends AbstractJacksonSerializationTest
         map.put( "key1", "value1" );
         map.put( "key2", "value2" );
         return new RenderableEmailRequest(
-                Optional.absent(),
+                Optional.empty(),
                 new String[] { "outage@openlattice.com" },
-                Optional.absent(),
-                Optional.absent(),
+                Optional.empty(),
+                Optional.empty(),
                 "OutageTemplate",
                 Optional.of( "Outage" ),
                 Optional.of( map ),
                 Optional.of( new EmailAttachment[] {} ),
-                Optional.absent() );
+                Optional.empty() );
     }
 
     @Override
@@ -59,30 +60,30 @@ public class RenderableEmailRequestTest extends AbstractJacksonSerializationTest
         expected = IllegalStateException.class )
     public void testNoTo() {
         new RenderableEmailRequest(
-                Optional.<String> absent(),
+                Optional.<String> empty(),
                 new String[] {},
-                Optional.<String[]> absent(),
-                Optional.<String[]> absent(),
+                Optional.<String[]> empty(),
+                Optional.<String[]> empty(),
                 "TemplateName",
-                Optional.<String> absent(),
-                Optional.<Object> absent(),
+                Optional.<String> empty(),
+                Optional.<Object> empty(),
                 Optional.of( new EmailAttachment[] {} ),
-                Optional.absent() );
+                Optional.empty() );
     }
 
     @Test(
         expected = NullPointerException.class )
     public void testNullTo() {
         new RenderableEmailRequest(
-                Optional.<String> absent(),
+                Optional.<String> empty(),
                 null,
-                Optional.<String[]> absent(),
-                Optional.<String[]> absent(),
+                Optional.<String[]> empty(),
+                Optional.<String[]> empty(),
                 "",
-                Optional.<String> absent(),
-                Optional.<Object> absent(),
+                Optional.<String> empty(),
+                Optional.<Object> empty(),
                 Optional.of( new EmailAttachment[] {} ),
-                Optional.absent() );
+                Optional.empty() );
     }
 
 }


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8